### PR TITLE
fix: only initialize once

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function toCurl(platform) {
 
 const originalOnSocket = http.ClientRequest.prototype.onSocket;
 
-http.ClientRequest.prototype.onSocket = function onSocket(socket) {
+function onSocket(socket) {
     var self = this,
         ondata = socket.ondata,
         write = socket.write;
@@ -169,4 +169,7 @@ http.ClientRequest.prototype.onSocket = function onSocket(socket) {
     originalOnSocket.call(this, socket);
 };
 
-http.ClientRequest.prototype.toCurl = toCurl;
+if(!http.ClientRequest.prototype.toCurl) {
+  http.ClientRequest.prototype.onSocket = onSocket;
+  http.ClientRequest.prototype.toCurl = toCurl;
+}


### PR DESCRIPTION
If you clear the require cache in between requires it was possible to initialise this module more than once wich led to more and more nested onSocket functions.

This caused troubles in modules that make use of clearing the require cache like jest does.